### PR TITLE
Add code retrieval and autosuggestion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>care.smith.top</groupId>
 	<artifactId>top-api</artifactId>
-	<version>0.7.6</version>
+	<version>0.7.7</version>
 
 	<name>TOP API</name>
 	<description>REST API of the TOP framework</description>

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -3,7 +3,7 @@ info:
   title: TOP API
   version: 0.7.6
   description: |-
-    API to manage phenotypes, repositories, ontologies and organisations and to execute phenotypic queries.
+    API to manage phenotypes, repositories, ontologies, external terminologies and organisations and to execute phenotypic queries.
 
     To interact with this API you need a JSON Web Token. You can request one as shown below with a curl example:
 
@@ -1355,6 +1355,109 @@ paths:
           $ref: '#/components/responses/UnexpectedError'
       tags:
         - user
+  /code:
+    parameters:
+      - $ref: '#/components/parameters/include'
+    get:
+      operationId: getCode
+      summary: Search for codes in coding systems.
+      parameters:
+        - name: term
+          in: query
+          description: Filter codes by term labels or synonyms.
+          schema:
+            type: string
+        - name: codeSystems
+          in: query
+          description: Filter codes by code systems.
+          schema:
+            type: array
+            $ref: '#/components/schemas/CodeSystem'
+        - $ref: '#/components/parameters/page'
+      responses:
+        '200':
+          description: List of codes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Code'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+      tags:
+        - code
+  /codesystem:
+    parameters:
+      - $ref: '#/components/parameters/include'
+    get:
+      operationId: getCodeSystems
+      summary: Search for code systems.
+      parameters:
+        - name: uri
+          in: query
+          description: Filter code systems by their id
+          schema:
+            type: string
+            format: uri
+        - name: name
+          in: query
+          description: Filter code systems by their name
+          schema:
+            type: string
+        - $ref: '#/components/parameters/page'
+      responses:
+        '200':
+          description: List of code systems.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CodeSystem'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+      tags:
+      - code
+  /code/suggest:
+    parameters:
+      - $ref: '#/components/parameters/include'
+    get:
+      operationId: getCodeSuggestions
+      summary: Search for codes in coding systems.
+      parameters:
+        - name: term
+          in: query
+          description: Filter codes by term labels or synonyms.
+          schema:
+            type: string
+        - name: codeSystems
+          in: query
+          description: Filter codes by code systems specified by their names.
+          schema:
+            type: array
+            items:
+              type: string
+        - $ref: '#/components/parameters/page'
+      responses:
+        '200':
+          description: List of codes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Code'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+      tags:
+        - code
 components:
   parameters:
     converter:
@@ -2082,6 +2185,9 @@ components:
       description: Code of a code system.
       type: object
       properties:
+        uri:
+          type: string
+          format: uri
         codeSystem:
           $ref: '#/components/schemas/CodeSystem'
         code:

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1355,23 +1355,68 @@ paths:
           $ref: '#/components/responses/UnexpectedError'
       tags:
         - user
-  /code:
+  /code/{codeSystemId}/{uri}:
     parameters:
       - $ref: '#/components/parameters/include'
     get:
       operationId: getCode
-      summary: Retrieve a specific code from an external code systems.
+      summary: Retrieve a specific code from an external code system.
       parameters:
-        - name: iri
-          in: query
-          description: Code IRI.
+        - name: uri
+          in: path
+          description: Code URI, double URL-encoded
           schema:
             type: string
+            format: uri
+          required: true
+          example: http://snomed.info/id/1004019008
         - name: codeSystemId
-          in: query
-          description: Filter codes by code systems.
+          in: path
+          description: Identifier of the code system that contains the code.
           schema:
             type: string
+          required: true
+          example: snomedct
+        - $ref: '#/components/parameters/page'
+      responses:
+        '200':
+          description: Details of the code.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Code'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+      tags:
+        - code
+  /code:
+    get:
+      operationId: getCodes
+      summary: Search for codes in external code systems by label.
+      parameters:
+        - $ref: '#/components/parameters/include'
+        - $ref: '#/components/parameters/codeLabel'
+        - $ref: '#/components/parameters/codeSystemIds'
+        - $ref: '#/components/parameters/page'
+      responses:
+        '200':
+          $ref: '#/components/responses/CodePageResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+      tags:
+        - code
+  /code/suggest:
+    get:
+      operationId: getCodeSuggestions
+      summary: Get autosuggestions for codes from external code systems.
+      parameters:
+        - $ref: '#/components/parameters/include'
+        - $ref: '#/components/parameters/codeLabel'
+        - $ref: '#/components/parameters/codeSystemIds'
         - $ref: '#/components/parameters/page'
       responses:
         '200':
@@ -1391,48 +1436,23 @@ paths:
       parameters:
         - name: uri
           in: query
-          description: Filter code systems by their id
+          description: Filter code systems by id(s)
+          example: http://snomed.info
+          required: false
           schema:
             type: string
             format: uri
         - name: name
           in: query
-          description: Filter code systems by their name
+          description: Filter code systems by name(s)
+          example: SNOMEDCD,LOINC
+          required: false
           schema:
             type: string
         - $ref: '#/components/parameters/page'
       responses:
         '200':
           $ref: '#/components/responses/CodeSystemPageResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        default:
-          $ref: '#/components/responses/UnexpectedError'
-      tags:
-        - code
-  /code/suggest:
-    parameters:
-      - $ref: '#/components/parameters/include'
-    get:
-      operationId: getCodeSuggestions
-      summary: Search for codes in coding systems.
-      parameters:
-        - name: term
-          in: query
-          description: Filter codes by term labels or synonyms.
-          schema:
-            type: string
-        - name: codeSystems
-          in: query
-          description: Filter codes by code systems specified by their names.
-          schema:
-            type: array
-            items:
-              type: string
-        - $ref: '#/components/parameters/page'
-      responses:
-        '200':
-          $ref: '#/components/responses/CodePageResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         default:
@@ -1560,6 +1580,23 @@ components:
       description: Defaults to the latest version number.
       schema:
         $ref: '#/components/schemas/VersionNumber'
+    codeLabel:
+      name: label
+      in: query
+      description: Filter codes by term labels (including synonyms).
+      example: growth
+      schema:
+        type: string
+    codeSystemIds:
+      name: codeSystemIds
+      in: query
+      description: Filter codes by code systems specified by their ids.
+      example: snomedct,loinc
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
   schemas:
     Page:
       type: object

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: TOP API
-  version: 0.7.6
+  version: 0.7.7
   description: |-
     API to manage phenotypes, repositories, ontologies, external terminologies and organisations and to execute phenotypic queries.
 

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1360,19 +1360,18 @@ paths:
       - $ref: '#/components/parameters/include'
     get:
       operationId: getCode
-      summary: Search for codes in coding systems.
+      summary: Retrieve a specific code from an external code systems.
       parameters:
-        - name: term
+        - name: iri
           in: query
-          description: Filter codes by term labels or synonyms.
+          description: Code IRI.
           schema:
             type: string
-        - name: codeSystems
+        - name: codeSystemId
           in: query
           description: Filter codes by code systems.
           schema:
-            type: array
-            $ref: '#/components/schemas/CodeSystem'
+            type: string
         - $ref: '#/components/parameters/page'
       responses:
         '200':
@@ -2182,9 +2181,13 @@ components:
         name:
           type: string
           example: LOINC
+        external_id:
+          type: string
+          example: loinc
       required:
         - uri
         - name
+        - external_id
     Code:
       description: Code of a code system.
       type: object
@@ -2201,6 +2204,11 @@ components:
         name:
           type: string
           example: Body height
+        synonyms:
+          type: array
+          items:
+            type: string
+          example: ["length of the body", "body size"]
       required:
         - codeSystem
         - code

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1376,20 +1376,14 @@ paths:
         - $ref: '#/components/parameters/page'
       responses:
         '200':
-          description: List of codes.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Code'
+          $ref: '#/components/responses/CodePageResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         default:
           $ref: '#/components/responses/UnexpectedError'
       tags:
         - code
-  /codesystem:
+  /code_system:
     parameters:
       - $ref: '#/components/parameters/include'
     get:
@@ -1410,19 +1404,13 @@ paths:
         - $ref: '#/components/parameters/page'
       responses:
         '200':
-          description: List of code systems.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CodeSystem'
+          $ref: '#/components/responses/CodeSystemPageResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         default:
           $ref: '#/components/responses/UnexpectedError'
       tags:
-      - code
+        - code
   /code/suggest:
     parameters:
       - $ref: '#/components/parameters/include'
@@ -1445,13 +1433,7 @@ paths:
         - $ref: '#/components/parameters/page'
       responses:
         '200':
-          description: List of codes.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Code'
+          $ref: '#/components/responses/CodePageResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         default:
@@ -1618,6 +1600,28 @@ components:
         - totalElements
         - totalPages
         - type
+    CodePage:
+      type: object
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/Code'
+          type: array
+      allOf:
+        - $ref: '#/components/schemas/Page'
+      required:
+        - content
+    CodeSystemPage:
+      type: object
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/CodeSystem'
+          type: array
+      allOf:
+        - $ref: '#/components/schemas/Page'
+      required:
+        - content
     ConceptPage:
       type: object
       properties:
@@ -2188,6 +2192,7 @@ components:
         uri:
           type: string
           format: uri
+          example: 'https://loinc.org/3137-7'
         codeSystem:
           $ref: '#/components/schemas/CodeSystem'
         code:
@@ -2534,6 +2539,18 @@ components:
           example:
             status: 500
             message: Unexpected error
+    CodePageResponse:
+      description: A page of codes.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CodePage'
+    CodeSystemPageResponse:
+      description: A page of code systems.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CodeSystemPage'
     ConceptPageResponse:
       description: A page of concepts.
       content:


### PR DESCRIPTION
This pull request is a compilation of [112-add-code-retrieval-and-autosuggestion-operations](https://github.com/Onto-Med/top-api/tree/112-add-code-retrieval-and-autosuggestion-operations). The original branch can be deleted after merge.

# Changes

* add property `uri` to `Code` schema
* add endpoints to query codes and codes systems
* add endpoint to get code suggestions based on text input