### PR TITLE
Support for declaring/receiving offsets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>care.smith.top</groupId>
 	<artifactId>top-api</artifactId>
-	<version>0.11.2-SNAPSHOT</version>
+	<version>0.11.2</version>
 
 	<name>TOP API</name>
 	<description>REST API of the TOP framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>care.smith.top</groupId>
 	<artifactId>top-api</artifactId>
-	<version>0.11.1</version>
+	<version>0.11.2-SNAPSHOT</version>
 
 	<name>TOP API</name>
 	<description>REST API of the TOP framework</description>

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1313,11 +1313,14 @@ paths:
       summary: Get the resulting ids (e.g. documents) of a particular query by ID.
       responses:
         '200':
-          description: List of documents ids.
+          description: Map of document ids to a list of offsets where entities were found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StringArray'
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/StringArray'
+
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: TOP API
-  version: 0.11.1
+  version: 0.11.2
   description: |-
     API to manage phenotypes, repositories, ontologies, external terminologies and organisations and to execute phenotypic queries.
 

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -132,6 +132,9 @@ paths:
             $ref: '#/components/schemas/StringArray'
         - name: offsets
           in: query
+          description: |
+            Highlights terms within a given offset in the form of e.g. '8-14'
+            (more precisely, an array of said representation is expected)
           schema:
             $ref: '#/components/schemas/StringArray'
         - $ref: '#/components/parameters/include'

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -130,6 +130,10 @@ paths:
             (e.g. [$color::#556b2f::color$21, $color::red::color$17])
           schema:
             $ref: '#/components/schemas/StringArray'
+        - name: offsets
+          in: query
+          schema:
+            $ref: '#/components/schemas/StringArray'
         - $ref: '#/components/parameters/include'
       responses:
         '200':


### PR DESCRIPTION
- offsets of terms that were featured in a search query are now returned alongside their documents
- when requesting a particular document, offsets can be provided to highlight everything in the offset span