### PR TITLE
CorpusId & Offsets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>top-api</artifactId>
 	<packaging>jar</packaging>
 	<name>TOP API</name>
-	<version>0.12.2-SNAPSHOT</version>
+	<version>0.12.2</version>
 	<description>REST API of the TOP framework</description>
 	<properties>
 		<java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>top-api</artifactId>
 	<packaging>jar</packaging>
 	<name>TOP API</name>
-	<version>0.12.2</version>
+	<version>0.12.2-SNAPSHOT</version>
 	<description>REST API of the TOP framework</description>
 	<properties>
 		<java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>top-api</artifactId>
 	<packaging>jar</packaging>
 	<name>TOP API</name>
-	<version>0.12.1</version>
+	<version>0.12.2</version>
 	<description>REST API of the TOP framework</description>
 	<properties>
 		<java.version>17</java.version>

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -2484,7 +2484,17 @@ components:
               documents:
                 type: array
                 items:
-                  type: string
+                  title: NodeDocuments
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    offsets:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: integer
     ConceptGraphPipeline:
       type: object
       properties:

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: TOP API
-  version: 0.12.1
+  version: 0.12.2
   description: |-
     API to manage phenotypes, repositories, ontologies, external terminologies and organisations and to execute phenotypic queries.
 

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -178,6 +178,7 @@ paths:
           description: Search phrase by a concept cluster id it is contained in
           schema:
             type: string
+        - $ref: '#/components/parameters/corpusId'
         - $ref: '#/components/parameters/page'
       responses:
         '200':
@@ -196,10 +197,12 @@ paths:
         required: true
         schema:
           type: string
-      - $ref: '#/components/parameters/include'
     get:
       operationId: getPhraseById
       summary: Returns a particular Phrase
+      parameters:
+        - $ref: '#/components/parameters/corpusId'
+        - $ref: '#/components/parameters/include'
       responses:
         '200':
           $ref: '#/components/responses/Phrase'


### PR DESCRIPTION
- added query value `corpusId` to some endpoints where it might be necessary to differentiate
- changed `ConceptGraph → Nodes → documents` property representation to allow for storing offsets where the phrases are found in the respective document