### PR TITLE
Minor addition to 'Statistic'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>top-api</artifactId>
 	<packaging>jar</packaging>
 	<name>TOP API</name>
-	<version>0.13.1</version>
+	<version>0.13.2</version>
 	<description>REST API of the TOP framework</description>
 	<properties>
 		<java.version>17</java.version>

--- a/schemas/top-api.yml
+++ b/schemas/top-api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: TOP API
-  version: 0.13.1
+  version: 0.13.2
   description: |-
     API to manage phenotypes, repositories, ontologies, external terminologies and organisations and to execute phenotypic queries.
 
@@ -3236,6 +3236,16 @@ components:
           format: int64
         documents:
           description: Number of documents
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/DocumentCounts'
+    DocumentCounts:
+      type: object
+      properties:
+        documentServer:
+          type: integer
+          format: int64
+        graphDB:
           type: integer
           format: int64
     Document:


### PR DESCRIPTION
'documents' property of 'Statistic' is now an object 'DocumentCounts' that differentiates between docs from the 'documentServer' and processed docs from the 'graphDB'